### PR TITLE
[S3T-447] NetworkAgent에서 서버 에러 처리

### DIFF
--- a/HeyLocal/HeyLocal/UI/Screens/MyPlanScreen/PlanDetailScreen.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/MyPlanScreen/PlanDetailScreen.swift
@@ -12,6 +12,8 @@ struct PlanDetailScreen: View {
 	
 	@ObservedObject var viewModel: ViewModel
 	
+	@Environment(\.presentationMode) var presentationMode
+	
 	init(plan: Plan) {
 		self.plan = plan
 		self.viewModel = ViewModel(plan: plan)
@@ -32,6 +34,11 @@ struct PlanDetailScreen: View {
 		.navigationBarTitleDisplayMode(.inline)
 		.onAppear {
 			viewModel.fetchPlaces()
+		}
+		.alert(isPresented: $viewModel.showErrorDialog) {
+			Alert(title: Text("에러"), message: Text("플랜을 찾을 수 없습니다."), dismissButton: .default(Text("뒤로 가기"), action: {
+				presentationMode.wrappedValue.dismiss()
+			}))
 		}
     }
 	

--- a/HeyLocal/HeyLocal/UI/Screens/MyPlanScreen/PlanDetailScreenViewModel.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/MyPlanScreen/PlanDetailScreenViewModel.swift
@@ -19,13 +19,21 @@ extension PlanDetailScreen {
 		@Published var currentDay = 1
 		@Published var schedules: [DaySchedule] = []
 		
+		@Published var showErrorDialog = false
+		
 		init(plan: Plan) {
 			self.plan = plan
 		}
 		
 		func fetchPlaces() {
 			cancellable = planService.getSchedules(planId: plan.id)
-				.sink(receiveCompletion: { _ in
+				.sink(receiveCompletion: { completion in
+					if case let .failure(error) = completion {
+//						let apiError: APIError = error as! APIError
+//						print(apiError.code)
+//						print(apiError.description)
+						self.showErrorDialog = true
+					}
 				}, receiveValue: { schedules in
 					self.schedules = schedules
 				})

--- a/HeyLocal/HeyLocal/Utils/NetworkAgent.swift
+++ b/HeyLocal/HeyLocal/Utils/NetworkAgent.swift
@@ -14,19 +14,23 @@ struct NetworkAgent {
 	func run<T: Decodable>(_ request: URLRequest) -> AnyPublisher<T, Error> {
 		return session
 			.dataTaskPublisher(for: request)
-			.tryMap { data, response in
-				if let httpResp = response as? HTTPURLResponse,
-				   100..<400 ~= httpResp.statusCode {
-					return data
-				} else {
-					let decoder = JSONDecoder()
-					let apiError = try decoder.decode(APIError.self, from: data)
-					throw apiError
-				}
-			}
+			.tryMap(handleAPIError)
 			.decode(type: T.self, decoder: JSONDecoder())
 			.receive(on: DispatchQueue.main)
 			.eraseToAnyPublisher()
+	}
+	
+	/// API에서 에러를 반환한 경우 Swift 에러로 throw하는 핸들러 메서드입니다.
+	private func handleAPIError(data: Data, response: URLResponse) throws -> Data {
+		guard let httpResp = response as? HTTPURLResponse,
+		   100..<400 ~= httpResp.statusCode
+		else {
+			let decoder = JSONDecoder()
+			let apiError = try decoder.decode(APIError.self, from: data)
+			throw apiError
+		}
+		
+		return data
 	}
 }
 

--- a/HeyLocal/HeyLocal/Utils/NetworkAgent.swift
+++ b/HeyLocal/HeyLocal/Utils/NetworkAgent.swift
@@ -14,9 +14,24 @@ struct NetworkAgent {
 	func run<T: Decodable>(_ request: URLRequest) -> AnyPublisher<T, Error> {
 		return session
 			.dataTaskPublisher(for: request)
-			.map(\.data)
+			.tryMap { data, response in
+				if let httpResp = response as? HTTPURLResponse,
+				   100..<400 ~= httpResp.statusCode {
+					return data
+				} else {
+					let decoder = JSONDecoder()
+					let apiError = try decoder.decode(APIError.self, from: data)
+					throw apiError
+				}
+			}
 			.decode(type: T.self, decoder: JSONDecoder())
 			.receive(on: DispatchQueue.main)
 			.eraseToAnyPublisher()
 	}
+}
+
+/// API에서 반환한 에러를 표현하기 위한 구조체입니다.
+struct APIError: Error, Decodable {
+	var code: String
+	var description: String
 }


### PR DESCRIPTION
## Changes

- 서버에서 에러 전송 시 NetworkAgent에서 에러 throw
- 플랜 상세 화면에 예외 처리 적용

## Note

- 각 에러 타입을 enum으로 만들어 관리해야 할지