### PR TITLE
[S3T-485] 카카오 API 연동 및 장소 검색 기능 구현

### DIFF
--- a/HeyLocal/HeyLocal.xcodeproj/project.pbxproj
+++ b/HeyLocal/HeyLocal.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		EF26CD9528C0FF12006D0D27 /* DateFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF26CD9428C0FF12006D0D27 /* DateFormat.swift */; };
 		EF3C060C28E0E53F003F3188 /* PlaceSearchScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3C060B28E0E53F003F3188 /* PlaceSearchScreen.swift */; };
 		EF3C060E28E0E666003F3188 /* PlaceSearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3C060D28E0E666003F3188 /* PlaceSearchViewModel.swift */; };
+		EF3C061228E0EDC4003F3188 /* KakaoAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3C061128E0EDC4003F3188 /* KakaoAPIService.swift */; };
 		EF3FCF1528C12A3900D48F9E /* PlanDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3FCF1428C12A3900D48F9E /* PlanDetailScreen.swift */; };
 		EF3FCF1728C12D0800D48F9E /* PlanDetailScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3FCF1628C12D0800D48F9E /* PlanDetailScreenViewModel.swift */; };
 		EF3FCF1928C1345C00D48F9E /* Place.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3FCF1828C1345C00D48F9E /* Place.swift */; };
@@ -132,6 +133,7 @@
 		EF26CD9428C0FF12006D0D27 /* DateFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormat.swift; sourceTree = "<group>"; };
 		EF3C060B28E0E53F003F3188 /* PlaceSearchScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceSearchScreen.swift; sourceTree = "<group>"; };
 		EF3C060D28E0E666003F3188 /* PlaceSearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceSearchViewModel.swift; sourceTree = "<group>"; };
+		EF3C061128E0EDC4003F3188 /* KakaoAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoAPIService.swift; sourceTree = "<group>"; };
 		EF3FCF1428C12A3900D48F9E /* PlanDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanDetailScreen.swift; sourceTree = "<group>"; };
 		EF3FCF1628C12D0800D48F9E /* PlanDetailScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanDetailScreenViewModel.swift; sourceTree = "<group>"; };
 		EF3FCF1828C1345C00D48F9E /* Place.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Place.swift; sourceTree = "<group>"; };
@@ -399,6 +401,7 @@
 				EFAA2AC428BBC48400B56A3C /* AuthService.swift */,
 				EF26CD8928C0EECA006D0D27 /* PlanService.swift */,
 				A80213DA28BF2EA100B6359E /* TravelOnService.swift */,
+				EF3C061128E0EDC4003F3188 /* KakaoAPIService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -673,6 +676,7 @@
 				A87F6CA628C0A3AB0076046E /* SettingScreen.swift in Sources */,
 				A87F6CA228C0A22B0076046E /* ProfileComponent.swift in Sources */,
 				A8A1999728BF59EF006119C4 /* CheckedValue.swift in Sources */,
+				EF3C061228E0EDC4003F3188 /* KakaoAPIService.swift in Sources */,
 				A84E841228B8C28600128D9B /* SignInScreen.swift in Sources */,
 				EF26CD8A28C0EECA006D0D27 /* PlanService.swift in Sources */,
 				EF26CD8D28C0F102006D0D27 /* MyPlanScreen.swift in Sources */,

--- a/HeyLocal/HeyLocal.xcodeproj/project.pbxproj
+++ b/HeyLocal/HeyLocal.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		EF26CD9128C0F153006D0D27 /* MyPlanList.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF26CD9028C0F153006D0D27 /* MyPlanList.swift */; };
 		EF26CD9328C0F15E006D0D27 /* MyPlanListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF26CD9228C0F15E006D0D27 /* MyPlanListViewModel.swift */; };
 		EF26CD9528C0FF12006D0D27 /* DateFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF26CD9428C0FF12006D0D27 /* DateFormat.swift */; };
+		EF3C060C28E0E53F003F3188 /* PlaceSearchScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3C060B28E0E53F003F3188 /* PlaceSearchScreen.swift */; };
+		EF3C060E28E0E666003F3188 /* PlaceSearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3C060D28E0E666003F3188 /* PlaceSearchViewModel.swift */; };
 		EF3FCF1528C12A3900D48F9E /* PlanDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3FCF1428C12A3900D48F9E /* PlanDetailScreen.swift */; };
 		EF3FCF1728C12D0800D48F9E /* PlanDetailScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3FCF1628C12D0800D48F9E /* PlanDetailScreenViewModel.swift */; };
 		EF3FCF1928C1345C00D48F9E /* Place.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3FCF1828C1345C00D48F9E /* Place.swift */; };
@@ -128,6 +130,8 @@
 		EF26CD9028C0F153006D0D27 /* MyPlanList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPlanList.swift; sourceTree = "<group>"; };
 		EF26CD9228C0F15E006D0D27 /* MyPlanListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPlanListViewModel.swift; sourceTree = "<group>"; };
 		EF26CD9428C0FF12006D0D27 /* DateFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormat.swift; sourceTree = "<group>"; };
+		EF3C060B28E0E53F003F3188 /* PlaceSearchScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceSearchScreen.swift; sourceTree = "<group>"; };
+		EF3C060D28E0E666003F3188 /* PlaceSearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceSearchViewModel.swift; sourceTree = "<group>"; };
 		EF3FCF1428C12A3900D48F9E /* PlanDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanDetailScreen.swift; sourceTree = "<group>"; };
 		EF3FCF1628C12D0800D48F9E /* PlanDetailScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanDetailScreenViewModel.swift; sourceTree = "<group>"; };
 		EF3FCF1828C1345C00D48F9E /* Place.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Place.swift; sourceTree = "<group>"; };
@@ -289,6 +293,15 @@
 			path = MyPlanList;
 			sourceTree = "<group>";
 		};
+		EF3C060A28E0E52F003F3188 /* PlaceSearchScreen */ = {
+			isa = PBXGroup;
+			children = (
+				EF3C060B28E0E53F003F3188 /* PlaceSearchScreen.swift */,
+				EF3C060D28E0E666003F3188 /* PlaceSearchViewModel.swift */,
+			);
+			path = PlaceSearchScreen;
+			sourceTree = "<group>";
+		};
 		EF3FCF1A28C135A700D48F9E /* PlaceList */ = {
 			isa = PBXGroup;
 			children = (
@@ -406,6 +419,7 @@
 		EF8FF26E28B4D1C400C053B7 /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				EF3C060A28E0E52F003F3188 /* PlaceSearchScreen */,
 				A87F6C9B28C099940076046E /* ProfileScreen */,
 				A83F100728BC4E6A00978711 /* TravelOnScreen */,
 				EF74BBF128B4D55A00E09450 /* HomeScreen */,
@@ -634,6 +648,7 @@
 				A87F6C9F28C0A1050076046E /* TopTabs.swift in Sources */,
 				A813CA3028B4F033000F0ADF /* SNSButtonStyle.swift in Sources */,
 				EF26CD9128C0F153006D0D27 /* MyPlanList.swift in Sources */,
+				EF3C060C28E0E53F003F3188 /* PlaceSearchScreen.swift in Sources */,
 				EFF9F3C728C5C8DA00E9FCB3 /* KakaoMap.swift in Sources */,
 				A80213DB28BF2EA100B6359E /* TravelOnService.swift in Sources */,
 				EF8FF27428B4D2D100C053B7 /* Main.swift in Sources */,
@@ -645,6 +660,7 @@
 				EFDC441B28C0735400E8747C /* PlanRepository.swift in Sources */,
 				EF3FCF1928C1345C00D48F9E /* Place.swift in Sources */,
 				EF8FF25D28B4D0B100C053B7 /* HeyLocalApp.swift in Sources */,
+				EF3C060E28E0E666003F3188 /* PlaceSearchViewModel.swift in Sources */,
 				A80213D928BF2D6C00B6359E /* User.swift in Sources */,
 				A87F6C9D28C099EE0076046E /* MyProfileScreen.swift in Sources */,
 				EFAA2ACD28BBD19400B56A3C /* SignInScreenTest.swift in Sources */,

--- a/HeyLocal/HeyLocal/Configurations/Main.xcconfig
+++ b/HeyLocal/HeyLocal/Configurations/Main.xcconfig
@@ -6,3 +6,6 @@
 //
 
 #include "Authorization.xcconfig"
+
+// 카카오 REST API URL
+KAKAO_REST_URL = https:${SLASH}/dapi.kakao.com

--- a/HeyLocal/HeyLocal/Info.plist
+++ b/HeyLocal/HeyLocal/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>지도를 통해 현재 위치를 제공하기 위해 위치 권한이 필요합니다.</string>
 	<key>API_URL</key>
 	<string>${API_URL}</string>
 	<key>ACCESS_TOKEN</key>
@@ -12,6 +10,12 @@
 	<string>${REFRESH_TOKEN}</string>
 	<key>KAKAO_APP_KEY</key>
 	<string>${KAKAO_APP_KEY}</string>
+	<key>KAKAO_REST_URL</key>
+	<string>${KAKAO_REST_URL}</string>
+	<key>KAKAO_REST_KEY</key>
+	<string>${KAKAO_REST_KEY}</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>지도를 통해 현재 위치를 제공하기 위해 위치 권한이 필요합니다.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>ko_KR</string>
 	<key>CFBundleIconName</key>

--- a/HeyLocal/HeyLocal/Models/Place.swift
+++ b/HeyLocal/HeyLocal/Models/Place.swift
@@ -16,7 +16,7 @@ struct Place: Decodable, Equatable {
 	var roadAddress: String
 	var lat: Double
 	var lng: Double
-	var kakaoLink: String
+	var link: String
 	
 	/// 카테고리의 이름 (ex. 음식점)
 	var categoryName: String {

--- a/HeyLocal/HeyLocal/Models/Place.swift
+++ b/HeyLocal/HeyLocal/Models/Place.swift
@@ -7,16 +7,60 @@
 
 import Foundation
 
-// 장소
+// MARK: - Place (장소)
 struct Place: Decodable, Equatable {
 	var id: Int
 	var name: String
+	var category: String
 	var address: String
 	var roadAddress: String
 	var lat: Double
 	var lng: Double
+	var kakaoLink: String
 	
+	/// 카테고리의 이름 (ex. 음식점)
+	var categoryName: String {
+		PlaceCategory.withLabel(category).rawValue
+	}
+	
+	/// Equatable 프로토콜 구현
+	/// 장소의 동일 여부는 오직 장소의 ID를 통해 판별합니다.
 	static func == (lhs: Place, rhs: Place) -> Bool {
 		lhs.id == rhs.id
+	}
+}
+
+
+// MARK: - PlaceCategory (장소 카테고리 종류)
+
+enum PlaceCategory: String, CaseIterable {
+	case MT1 = "대형마트"
+	case CS2 = "편의점"
+	case PS3 = "어린이집, 유치원"
+	case SC4 = "학교"
+	case AC5 = "학원"
+	case PK6 = "주차장"
+	case OL7 = "주유소, 충전소"
+	case SW8 = "지하철역"
+	case BK9 = "은행"
+	case CT1 = "문화시설"
+	case AG2 = "중개업소"
+	case PO3 = "공공기관"
+	case AT4 = "관광명소"
+	case AD5 = "숙박"
+	case FD6 = "음식점"
+	case CE7 = "카페"
+	case HP8 = "병원"
+	case PM9 = "약국"
+	case ETC = "기타"
+	
+	/// 열거형의 라벨을 파라미터로 받아 열거형 객체를 반환합니다.
+	/// 매칭되는 라벨이 없는 경우에는 PlaceCategory.ETC를 반환합니다.
+	static func withLabel(_ label: String) -> PlaceCategory {
+		if let placeCategory = self.allCases.first(where: { "\($0)" == label }) {
+			return placeCategory
+		}
+		
+		return .ETC // 매칭된 라벨이 없는 경우
 	}
 }

--- a/HeyLocal/HeyLocal/Models/Place.swift
+++ b/HeyLocal/HeyLocal/Models/Place.swift
@@ -8,11 +8,15 @@
 import Foundation
 
 // 장소
-struct Place: Decodable {
+struct Place: Decodable, Equatable {
 	var id: Int
 	var name: String
 	var address: String
 	var roadAddress: String
 	var lat: Double
 	var lng: Double
+	
+	static func == (lhs: Place, rhs: Place) -> Bool {
+		lhs.id == rhs.id
+	}
 }

--- a/HeyLocal/HeyLocal/Services/KakaoAPIService.swift
+++ b/HeyLocal/HeyLocal/Services/KakaoAPIService.swift
@@ -90,10 +90,12 @@ struct KakaoPlacesResponse: Decodable {
 			Place(
 				id: Int(id) ?? 0,
 				name: name,
+				category: category,
 				address: address,
 				roadAddress: roadAddress,
 				lat: Double(lat) ?? 0.0,
-				lng: Double(lng) ?? 0.0
+				lng: Double(lng) ?? 0.0,
+				kakaoLink: kakaoLink
 			)
 		}
 	}

--- a/HeyLocal/HeyLocal/Services/KakaoAPIService.swift
+++ b/HeyLocal/HeyLocal/Services/KakaoAPIService.swift
@@ -17,7 +17,7 @@ class KakaoAPIService {
 	var cancellable: AnyCancellable?
 	
 	/// 장소 목록 검색 (페이징)
-	func loadPlaces(query: String, page: Int, pageSize: Int, places: Binding<[Place]>) {
+	func loadPlaces(query: String, page: Int, pageSize: Int, places: Binding<[Place]>, isLastPage: Binding<Bool>) {
 		// URL 구성
 		var components = URLComponents(string: "\(Config.kakaoRestURL)/v2/local/search/keyword.json")!
 		components.queryItems = [
@@ -41,7 +41,8 @@ class KakaoAPIService {
 				}
 			}, receiveValue: { (resp: KakaoPlacesResponse) in
 				let newPlaces = resp.documents.map(\.place)
-				places.wrappedValue = newPlaces
+				places.wrappedValue.append(contentsOf: newPlaces)
+				isLastPage.wrappedValue = resp.meta.isEnd
 			})
 	}
 }

--- a/HeyLocal/HeyLocal/Services/KakaoAPIService.swift
+++ b/HeyLocal/HeyLocal/Services/KakaoAPIService.swift
@@ -6,12 +6,15 @@
 //
 
 import Foundation
+import Combine
 import SwiftUI
 
 // MARK: - KakaoAPIService (카카오 API 호출 서비스)
 
-struct KakaoAPIService {
+class KakaoAPIService {
 	let agent = NetworkAgent()
+	
+	var cancellable: AnyCancellable?
 	
 	/// 장소 목록 검색 (페이징)
 	func loadPlaces(query: String, page: Int, pageSize: Int, places: Binding<[Place]>) {
@@ -31,7 +34,7 @@ struct KakaoAPIService {
 		request.addValue("KakaoAK \(Config.kakaoRestKey)", forHTTPHeaderField: "Authorization")
 		
 		// 실행
-		var cancellable = agent.run(request)
+		self.cancellable = agent.run(request)
 			.sink(receiveCompletion: { completion in
 				if case let .failure(error) = completion {
 					print(error)
@@ -62,13 +65,13 @@ struct KakaoPlacesResponse: Decodable {
 	}
 	
 	struct Document: Decodable {
-		var id: Int
+		var id: String
 		var name: String
 		var category: String
 		var address: String
 		var roadAddress: String
-		var lat: Double
-		var lng: Double
+		var lat: String
+		var lng: String
 		var kakaoLink: String
 		
 		enum CodingKeys: String, CodingKey {
@@ -83,7 +86,14 @@ struct KakaoPlacesResponse: Decodable {
 		}
 		
 		var place: Place {
-			Place(id: id, name: name, address: address, roadAddress: roadAddress, lat: lat, lng: lng)
+			Place(
+				id: Int(id) ?? 0,
+				name: name,
+				address: address,
+				roadAddress: roadAddress,
+				lat: Double(lat) ?? 0.0,
+				lng: Double(lng) ?? 0.0
+			)
 		}
 	}
 }

--- a/HeyLocal/HeyLocal/Services/KakaoAPIService.swift
+++ b/HeyLocal/HeyLocal/Services/KakaoAPIService.swift
@@ -73,7 +73,7 @@ struct KakaoPlacesResponse: Decodable {
 		var roadAddress: String
 		var lat: String
 		var lng: String
-		var kakaoLink: String
+		var link: String
 		
 		enum CodingKeys: String, CodingKey {
 			case id = "id"
@@ -83,7 +83,7 @@ struct KakaoPlacesResponse: Decodable {
 			case roadAddress = "road_address_name"
 			case lat = "y"
 			case lng = "x"
-			case kakaoLink = "place_url"
+			case link = "place_url"
 		}
 		
 		var place: Place {
@@ -95,7 +95,7 @@ struct KakaoPlacesResponse: Decodable {
 				roadAddress: roadAddress,
 				lat: Double(lat) ?? 0.0,
 				lng: Double(lng) ?? 0.0,
-				kakaoLink: kakaoLink
+				link: link
 			)
 		}
 	}

--- a/HeyLocal/HeyLocal/Services/KakaoAPIService.swift
+++ b/HeyLocal/HeyLocal/Services/KakaoAPIService.swift
@@ -41,7 +41,7 @@ class KakaoAPIService {
 				}
 			}, receiveValue: { (resp: KakaoPlacesResponse) in
 				let newPlaces = resp.documents.map(\.place)
-				places.wrappedValue.append(contentsOf: newPlaces)
+				places.wrappedValue = newPlaces
 			})
 	}
 }

--- a/HeyLocal/HeyLocal/Services/KakaoAPIService.swift
+++ b/HeyLocal/HeyLocal/Services/KakaoAPIService.swift
@@ -1,0 +1,89 @@
+//
+//  KakaoAPIService.swift
+//  HeyLocal
+//
+//  Copyright (c) 2022 TGT All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+// MARK: - KakaoAPIService (카카오 API 호출 서비스)
+
+struct KakaoAPIService {
+	let agent = NetworkAgent()
+	
+	/// 장소 목록 검색 (페이징)
+	func loadPlaces(query: String, page: Int, pageSize: Int, places: Binding<[Place]>) {
+		// URL 구성
+		var components = URLComponents(string: "\(Config.kakaoRestURL)/v2/local/search/keyword.json")!
+		components.queryItems = [
+			URLQueryItem(name: "query", value: query),
+			URLQueryItem(name: "sort", value: "accuracy"),
+			URLQueryItem(name: "page", value: "\(page)"),
+			URLQueryItem(name: "size", value: "\(pageSize)")
+		]
+		
+		// Request 생성
+		guard let url = components.url else { return }
+		var request = URLRequest(url: url)
+		request.httpMethod = "GET"
+		request.addValue("KakaoAK \(Config.kakaoRestKey)", forHTTPHeaderField: "Authorization")
+		
+		// 실행
+		var cancellable = agent.run(request)
+			.sink(receiveCompletion: { completion in
+				if case let .failure(error) = completion {
+					print(error)
+				}
+			}, receiveValue: { (resp: KakaoPlacesResponse) in
+				let newPlaces = resp.documents.map(\.place)
+				places.wrappedValue.append(contentsOf: newPlaces)
+			})
+	}
+}
+
+// MARK: - KakaoPlacesResponse (카카오 API 응답 객체)
+
+struct KakaoPlacesResponse: Decodable {
+	var meta: Meta
+	var documents: [Document]
+	
+	struct Meta: Decodable {
+		var totalCount: Int
+		var pageableCount: Int
+		var isEnd: Bool
+		
+		private enum CodingKeys: String, CodingKey {
+			case totalCount = "total_count"
+			case pageableCount = "pageable_count"
+			case isEnd = "is_end"
+		}
+	}
+	
+	struct Document: Decodable {
+		var id: Int
+		var name: String
+		var category: String
+		var address: String
+		var roadAddress: String
+		var lat: Double
+		var lng: Double
+		var kakaoLink: String
+		
+		enum CodingKeys: String, CodingKey {
+			case id = "id"
+			case name = "place_name"
+			case category = "category_group_code"
+			case address = "address_name"
+			case roadAddress = "road_address_name"
+			case lat = "y"
+			case lng = "x"
+			case kakaoLink = "place_url"
+		}
+		
+		var place: Place {
+			Place(id: id, name: name, address: address, roadAddress: roadAddress, lat: lat, lng: lng)
+		}
+	}
+}

--- a/HeyLocal/HeyLocal/UI/Components/PlaceList/PlaceList.swift
+++ b/HeyLocal/HeyLocal/UI/Components/PlaceList/PlaceList.swift
@@ -44,11 +44,11 @@ struct PlaceList: View {
 struct PlaceList_Previews: PreviewProvider {
     static var previews: some View {
         PlaceList(places: [
-			Place(id: 1, name: "해운대", address: "", roadAddress: "", lat: 0, lng: 0),
-			Place(id: 2, name: "부산꼼장어", address: "", roadAddress: "", lat: 0, lng: 0),
-			Place(id: 3, name: "감천 문화마을", address: "", roadAddress: "", lat: 0, lng: 0),
-			Place(id: 4, name: "광안대교", address: "", roadAddress: "", lat: 0, lng: 0),
-			Place(id: 5, name: "시그니엘 부산", address: "", roadAddress: "", lat: 0, lng: 0)
+			Place(id: 1, name: "해운대", category: "FD6", address: "", roadAddress: "", lat: 0, lng: 0, kakaoLink: ""),
+			Place(id: 2, name: "부산꼼장어", category: "FD6", address: "", roadAddress: "", lat: 0, lng: 0, kakaoLink: ""),
+			Place(id: 3, name: "감천 문화마을", category: "FD6", address: "", roadAddress: "", lat: 0, lng: 0, kakaoLink: ""),
+			Place(id: 4, name: "광안대교", category: "FD6", address: "", roadAddress: "", lat: 0, lng: 0, kakaoLink: ""),
+			Place(id: 5, name: "시그니엘 부산", category: "FD6", address: "", roadAddress: "", lat: 0, lng: 0, kakaoLink: "")
 		])
     }
 }

--- a/HeyLocal/HeyLocal/UI/Components/PlaceList/PlaceList.swift
+++ b/HeyLocal/HeyLocal/UI/Components/PlaceList/PlaceList.swift
@@ -44,11 +44,11 @@ struct PlaceList: View {
 struct PlaceList_Previews: PreviewProvider {
     static var previews: some View {
         PlaceList(places: [
-			Place(id: 1, name: "해운대", category: "FD6", address: "", roadAddress: "", lat: 0, lng: 0, kakaoLink: ""),
-			Place(id: 2, name: "부산꼼장어", category: "FD6", address: "", roadAddress: "", lat: 0, lng: 0, kakaoLink: ""),
-			Place(id: 3, name: "감천 문화마을", category: "FD6", address: "", roadAddress: "", lat: 0, lng: 0, kakaoLink: ""),
-			Place(id: 4, name: "광안대교", category: "FD6", address: "", roadAddress: "", lat: 0, lng: 0, kakaoLink: ""),
-			Place(id: 5, name: "시그니엘 부산", category: "FD6", address: "", roadAddress: "", lat: 0, lng: 0, kakaoLink: "")
+			Place(id: 1, name: "해운대", category: "FD6", address: "", roadAddress: "", lat: 0, lng: 0, link: ""),
+			Place(id: 2, name: "부산꼼장어", category: "FD6", address: "", roadAddress: "", lat: 0, lng: 0, link: ""),
+			Place(id: 3, name: "감천 문화마을", category: "FD6", address: "", roadAddress: "", lat: 0, lng: 0, link: ""),
+			Place(id: 4, name: "광안대교", category: "FD6", address: "", roadAddress: "", lat: 0, lng: 0, link: ""),
+			Place(id: 5, name: "시그니엘 부산", category: "FD6", address: "", roadAddress: "", lat: 0, lng: 0, link: "")
 		])
     }
 }

--- a/HeyLocal/HeyLocal/UI/Screens/MyPlanScreen/PlanDetailScreen.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/MyPlanScreen/PlanDetailScreen.swift
@@ -34,9 +34,6 @@ struct PlanDetailScreen: View {
 		}
 		.navigationTitle("마이 플랜")
 		.navigationBarTitleDisplayMode(.inline)
-		.onAppear {
-			viewModel.fetchPlaces()
-		}
 		.alert(isPresented: $viewModel.showErrorDialog) {
 			Alert(title: Text("에러"), message: Text("플랜을 찾을 수 없습니다."), dismissButton: .default(Text("뒤로 가기"), action: {
 				presentationMode.wrappedValue.dismiss()
@@ -85,10 +82,12 @@ struct PlanDetailScreen: View {
 	var placesView: some View {
 		VStack {
 			// 장소 추가 버튼
-			NavigationLink(destination: PlaceSearchScreen(places: $viewModel.schedules[viewModel.currentDay - 1].places)) {
-				Text("해당 일자에 장소 추가하기")
+			if !viewModel.schedules.isEmpty {
+				NavigationLink(destination: PlaceSearchScreen(places: $viewModel.schedules[viewModel.currentDay - 1].places)) {
+					Text("해당 일자에 장소 추가하기")
+				}
+				.padding()
 			}
-			.padding()
 			
 			// 장소 리스트
 			TabView(selection: $viewModel.currentDay) {

--- a/HeyLocal/HeyLocal/UI/Screens/MyPlanScreen/PlanDetailScreen.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/MyPlanScreen/PlanDetailScreen.swift
@@ -83,10 +83,10 @@ struct PlanDetailScreen: View {
 	var placesView: some View {
 		VStack {
 			// 장소 추가 버튼
-			Button {
-			} label: {
+			NavigationLink(destination: PlaceSearchScreen()) {
 				Text("해당 일자에 장소 추가하기")
-			}.padding()
+			}
+			.padding()
 			
 			// 장소 리스트
 			TabView(selection: $viewModel.currentDay) {

--- a/HeyLocal/HeyLocal/UI/Screens/MyPlanScreen/PlanDetailScreen.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/MyPlanScreen/PlanDetailScreen.swift
@@ -14,6 +14,8 @@ struct PlanDetailScreen: View {
 	
 	@Environment(\.presentationMode) var presentationMode
 	
+	@State var placeSelection: [Place] = []
+	
 	init(plan: Plan) {
 		self.plan = plan
 		self.viewModel = ViewModel(plan: plan)
@@ -83,7 +85,7 @@ struct PlanDetailScreen: View {
 	var placesView: some View {
 		VStack {
 			// 장소 추가 버튼
-			NavigationLink(destination: PlaceSearchScreen()) {
+			NavigationLink(destination: PlaceSearchScreen(places: $viewModel.schedules[viewModel.currentDay - 1].places)) {
 				Text("해당 일자에 장소 추가하기")
 			}
 			.padding()

--- a/HeyLocal/HeyLocal/UI/Screens/MyPlanScreen/PlanDetailScreenViewModel.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/MyPlanScreen/PlanDetailScreenViewModel.swift
@@ -23,6 +23,7 @@ extension PlanDetailScreen {
 		
 		init(plan: Plan) {
 			self.plan = plan
+			fetchPlaces()
 		}
 		
 		func fetchPlaces() {

--- a/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchScreen.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchScreen.swift
@@ -119,7 +119,7 @@ extension PlaceSearchScreen {
 				Text(item.name) // 이름
 					.font(.title3)
 					.fontWeight(.bold)
-				Text(item.address) // 주소
+				Text("\(item.categoryName) | \(item.address)") // 주소
 					.font(.subheadline)
 			}
 			

--- a/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchScreen.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchScreen.swift
@@ -17,13 +17,14 @@ struct PlaceSearchScreen: View {
 			searchForm
 			selectedItemList
 			searchedItemList
-			recommendation
+			// recommendation
 		}
 		.navigationTitle("장소 검색")
 		.navigationBarTitleDisplayMode(.inline)
 		.toolbar {
 			Button("완료") {}
 		}
+		.padding()
     }
 }
 
@@ -34,6 +35,8 @@ extension PlaceSearchScreen {
 	var searchForm: some View {
 		HStack {
 			TextField("검색어", text: $viewModel.query)
+				.background(Color.init(red: 0, green: 0, blue: 0, opacity: 0.1))
+				.cornerRadius(5)
 			Button("검색") {
 				viewModel.fetchSearchedItems()
 			}
@@ -73,9 +76,22 @@ extension PlaceSearchScreen {
 	}
 	
 	func searchedItem(_ item: Place) -> some View {
-		HStack {
-			Text(item.name)
+		HStack(alignment: .center) {
+			RoundedRectangle(cornerRadius: 5) // 썸네일 이미지
+				.fill(.gray)
+				.frame(width: 50, height: 50)
+			
+			VStack(alignment: .leading) {
+				Text(item.name) // 이름
+					.font(.title3)
+					.fontWeight(.bold)
+				Text(item.address) // 주소
+					.font(.subheadline)
+			}
+			
+			Spacer()
 		}
+		.frame(height: 70)
 	}
 }
 

--- a/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchScreen.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchScreen.swift
@@ -7,10 +7,87 @@
 
 import SwiftUI
 
+// MARK: - PlaceSearchScreen (장소 검색 화면)
+
 struct PlaceSearchScreen: View {
+	@ObservedObject var viewModel = ViewModel()
+	
     var body: some View {
-        Text("Hello, World!")
+		VStack {
+			searchForm
+			selectedItemList
+			searchedItemList
+			recommendation
+		}
+		.navigationTitle("장소 검색")
+		.navigationBarTitleDisplayMode(.inline)
+		.toolbar {
+			Button("완료") {}
+		}
     }
+}
+
+
+// MARK: - searchForm (검색 폼)
+
+extension PlaceSearchScreen {
+	var searchForm: some View {
+		HStack {
+			TextField("검색어", text: $viewModel.query)
+			Button("검색") {
+				viewModel.fetchSearchedItems()
+			}
+		}
+	}
+}
+
+
+// MARK: - selectedItemList (선택한 장소 목록)
+
+extension PlaceSearchScreen {
+	var selectedItemList: some View {
+		ScrollView(.horizontal, showsIndicators: false) {
+			HStack {
+				ForEach(viewModel.selectedItems, id: \.id) { selectedItem($0) }
+			}
+		}
+	}
+	
+	func selectedItem(_ item: Place) -> some View {
+		HStack {
+			Text(item.name)
+		}
+	}
+}
+
+
+// MARK: - searchedItemList (검색 결과)
+
+extension PlaceSearchScreen {
+	var searchedItemList: some View {
+		ScrollView {
+			VStack(alignment: .leading) {
+				ForEach(viewModel.searchedItems, id: \.id) { searchedItem($0) }
+			}
+		}
+	}
+	
+	func searchedItem(_ item: Place) -> some View {
+		HStack {
+			Text(item.name)
+		}
+	}
+}
+
+
+// MARK: - recommendation (추천 장소 제안)
+
+extension PlaceSearchScreen {
+	var recommendation: some View {
+		VStack {
+			Text("이런 곳은 어떤가요?")
+		}
+	}
 }
 
 struct PlaceSearchScreen_Previews: PreviewProvider {

--- a/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchScreen.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchScreen.swift
@@ -90,6 +90,15 @@ extension PlaceSearchScreen {
 			}
 			
 			Spacer()
+			
+			if (viewModel.isSelected(item)) {
+				Button("선택") {}
+					.disabled(true)
+			} else {
+				Button("선택") { // 장소 선택 버튼
+					viewModel.addSelectedItem(item)
+				}
+			}
 		}
 		.frame(height: 70)
 	}

--- a/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchScreen.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchScreen.swift
@@ -84,7 +84,7 @@ extension PlaceSearchScreen {
 extension PlaceSearchScreen {
 	var searchedItemList: some View {
 		ScrollView {
-			LazyVStack(alignment: .leading) {
+			LazyVStack(alignment: .center) {
 				// 검색 결과
 				ForEach(viewModel.searchedItems, id: \.id) { searchedItem($0) }
 				

--- a/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchScreen.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchScreen.swift
@@ -11,6 +11,10 @@ import SwiftUI
 
 struct PlaceSearchScreen: View {
 	@ObservedObject var viewModel = ViewModel()
+	@Environment(\.presentationMode) var presentationMode
+	
+	/// 장소 선택 결과를 반환하기 위한 @Binding 파라미터
+	@Binding var places: [Place]
 	
     var body: some View {
 		VStack {
@@ -22,9 +26,15 @@ struct PlaceSearchScreen: View {
 		.navigationTitle("장소 검색")
 		.navigationBarTitleDisplayMode(.inline)
 		.toolbar {
-			Button("완료") {}
+			Button("완료", action: handleComplete)
 		}
     }
+	
+	/// 완료 버튼 클릭 시 이전 화면으로 Go Back
+	func handleComplete() {
+		places.append(contentsOf: viewModel.selectedItems)
+		presentationMode.wrappedValue.dismiss()
+	}
 }
 
 
@@ -142,6 +152,6 @@ extension PlaceSearchScreen {
 
 struct PlaceSearchScreen_Previews: PreviewProvider {
     static var previews: some View {
-        PlaceSearchScreen()
+		PlaceSearchScreen(places: .constant([]))
     }
 }

--- a/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchScreen.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchScreen.swift
@@ -1,0 +1,20 @@
+//
+//  PlaceSearchScreen.swift
+//  HeyLocal
+//
+//  Copyright (c) 2022 TGT All rights reserved.
+//
+
+import SwiftUI
+
+struct PlaceSearchScreen: View {
+    var body: some View {
+        Text("Hello, World!")
+    }
+}
+
+struct PlaceSearchScreen_Previews: PreviewProvider {
+    static var previews: some View {
+        PlaceSearchScreen()
+    }
+}

--- a/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchScreen.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchScreen.swift
@@ -85,12 +85,14 @@ extension PlaceSearchScreen {
 	var searchedItemList: some View {
 		ScrollView {
 			LazyVStack(alignment: .leading) {
+				// 검색 결과
 				ForEach(viewModel.searchedItems, id: \.id) { searchedItem($0) }
 				
-				if (!viewModel.searchedItems.isEmpty && !viewModel.isLastPage) {
+				// 스피너가 노출되면 다음 페이지 로드
+				if (!viewModel.isLastPage) {
 					ProgressView()
 						.onAppear {
-							viewModel.loadMore()
+							viewModel.searchNextPage()
 						}
 				}
 			}

--- a/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchScreen.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchScreen.swift
@@ -37,7 +37,7 @@ extension PlaceSearchScreen {
 				.background(Color.init(red: 0, green: 0, blue: 0, opacity: 0.1))
 				.cornerRadius(5)
 			Button("검색") {
-				viewModel.fetchSearchedItems()
+				viewModel.search()
 			}
 		}
 		.padding()
@@ -84,8 +84,15 @@ extension PlaceSearchScreen {
 extension PlaceSearchScreen {
 	var searchedItemList: some View {
 		ScrollView {
-			VStack(alignment: .leading) {
+			LazyVStack(alignment: .leading) {
 				ForEach(viewModel.searchedItems, id: \.id) { searchedItem($0) }
+				
+				if (!viewModel.searchedItems.isEmpty && !viewModel.isLastPage) {
+					ProgressView()
+						.onAppear {
+							viewModel.loadMore()
+						}
+				}
 			}
 		}
 	}

--- a/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchScreen.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchScreen.swift
@@ -24,7 +24,6 @@ struct PlaceSearchScreen: View {
 		.toolbar {
 			Button("완료") {}
 		}
-		.padding()
     }
 }
 
@@ -41,6 +40,7 @@ extension PlaceSearchScreen {
 				viewModel.fetchSearchedItems()
 			}
 		}
+		.padding()
 	}
 }
 
@@ -54,6 +54,7 @@ extension PlaceSearchScreen {
 				ForEach(viewModel.selectedItems, id: \.id) { selectedItem($0) }
 			}
 		}
+		.padding(.horizontal)
 	}
 	
 	func selectedItem(_ item: Place) -> some View {
@@ -115,6 +116,7 @@ extension PlaceSearchScreen {
 			}
 		}
 		.frame(height: 70)
+		.padding(.horizontal)
 	}
 }
 

--- a/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchScreen.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchScreen.swift
@@ -57,9 +57,23 @@ extension PlaceSearchScreen {
 	}
 	
 	func selectedItem(_ item: Place) -> some View {
-		HStack {
-			Text(item.name)
+		ZStack(alignment: .topTrailing) {
+			VStack(alignment: .center) {
+				RoundedRectangle(cornerRadius: 5) // 썸네일 이미지
+					.fill(.gray)
+					.frame(width: 50, height: 50)
+				Text(item.name) // 이름
+					.font(.subheadline)
+			}
+			.frame(width: 50, height: 70)
+			
+			Button { // 선택 취소 버튼
+				viewModel.removeSelectedItem(item)
+			} label: {
+				Image(systemName: "x.circle.fill")
+			}
 		}
+		.frame(width: 60, height: 80)
 	}
 }
 

--- a/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchViewModel.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchViewModel.swift
@@ -1,0 +1,19 @@
+//
+//  PlaceSearchViewModel.swift
+//  HeyLocal
+//
+//  Copyright (c) 2022 TGT All rights reserved.
+//
+
+import Foundation
+
+extension PlaceSearchScreen {
+	class ViewModel: ObservableObject {
+		// States
+		@Published var query = ""
+		@Published var selectedItems = [Place]()
+		@Published var searchedItems = [Place]()
+		
+		func fetchSearchedItems() { }
+	}
+}

--- a/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchViewModel.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchViewModel.swift
@@ -6,14 +6,29 @@
 //
 
 import Foundation
+import SwiftUI
 
 extension PlaceSearchScreen {
 	class ViewModel: ObservableObject {
+		// Dependencies
+		let kakaoAPIService = KakaoAPIService()
+		
 		// States
 		@Published var query = ""
 		@Published var selectedItems = [Place]()
 		@Published var searchedItems = [Place]()
 		
-		func fetchSearchedItems() { }
+		func fetchSearchedItems() {
+			if query.isEmpty { return }
+			kakaoAPIService.loadPlaces(
+				query: query,
+				page: 1,
+				pageSize: 15,
+				places: Binding(
+					get: { self.searchedItems },
+					set: { self.searchedItems = $0 }
+				)
+			)
+		}
 	}
 }

--- a/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchViewModel.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchViewModel.swift
@@ -17,16 +17,56 @@ extension PlaceSearchScreen {
 		@Published var query = ""
 		@Published var selectedItems = [Place]()
 		@Published var searchedItems = [Place]()
+		@Published var currentPage = 1
+		@Published var isLastPage = false
 		
-		func fetchSearchedItems() {
+		// 검색어가 바뀌고 검색 버튼이 눌리면,
+		// currentPage를 1로 초기화하고
+		// searchedItems를 비워야 함
+		
+		let pageSize = 15
+		
+		func search() {
 			if query.isEmpty { return }
+			
+			// 초기화
+			currentPage = 1
+			searchedItems.removeAll()
+			isLastPage = false
+			
+			// 검색
 			kakaoAPIService.loadPlaces(
 				query: query,
-				page: 1,
-				pageSize: 15,
+				page: currentPage,
+				pageSize: pageSize,
 				places: Binding(
 					get: { self.searchedItems },
 					set: { self.searchedItems = $0 }
+				),
+				isLastPage: Binding(
+					get: { self.isLastPage },
+					set: { self.isLastPage = $0 }
+				)
+			)
+		}
+		
+		func loadMore() {
+			if query.isEmpty { return }
+			if isLastPage { return }
+			
+			currentPage += 1
+			
+			kakaoAPIService.loadPlaces(
+				query: query,
+				page: currentPage,
+				pageSize: pageSize,
+				places: Binding(
+					get: { self.searchedItems },
+					set: { self.searchedItems = $0 }
+				),
+				isLastPage: Binding(
+					get: { self.isLastPage },
+					set: { self.isLastPage = $0 }
 				)
 			)
 		}

--- a/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchViewModel.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchViewModel.swift
@@ -8,83 +8,90 @@
 import Foundation
 import SwiftUI
 
+// MARK: - PlaceSearchScreen.ViewModel (뷰 모델)
+
 extension PlaceSearchScreen {
 	class ViewModel: ObservableObject {
-		// Dependencies
-		let kakaoAPIService = KakaoAPIService()
+		let kakaoAPIService = KakaoAPIService() // 의존성
 		
-		// States
-		@Published var query = ""
-		@Published var selectedItems = [Place]()
-		@Published var searchedItems = [Place]()
-		@Published var currentPage = 1
-		@Published var isLastPage = false
+		@Published var query = "" // 검색어
+		@Published var searchedItems = [Place]() // 검색 결과
+		@Published var currentPage = 1 // 현재까지 로드한 페이지
+		@Published var isLastPage = true // 마지막 페이지에 도달했는지
+		let pageSize = 15 // 한 페이지당 아이템 개수
 		
-		// 검색어가 바뀌고 검색 버튼이 눌리면,
-		// currentPage를 1로 초기화하고
-		// searchedItems를 비워야 함
-		
-		let pageSize = 15
-		
-		func search() {
-			if query.isEmpty { return }
-			
-			// 초기화
-			currentPage = 1
-			searchedItems.removeAll()
-			isLastPage = false
-			
-			// 검색
-			kakaoAPIService.loadPlaces(
-				query: query,
-				page: currentPage,
-				pageSize: pageSize,
-				places: Binding(
-					get: { self.searchedItems },
-					set: { self.searchedItems = $0 }
-				),
-				isLastPage: Binding(
-					get: { self.isLastPage },
-					set: { self.isLastPage = $0 }
-				)
+		@Published var selectedItems = [Place]() // 선택된 장소들
+	}
+}
+
+
+// MARK: - 장소 검색 기능
+
+extension PlaceSearchScreen.ViewModel {
+	/// 카카오 로컬 API를 통해 장소를 검색합니다.
+	/// 검색 결과는 기존 self.places의 끝에 추가됩니다.
+	private func fetchSearchedItems() {
+		kakaoAPIService.loadPlaces(
+			query: query,
+			page: currentPage,
+			pageSize: pageSize,
+			places: Binding(
+				get: { self.searchedItems },
+				set: { self.searchedItems = $0 }
+			),
+			isLastPage: Binding(
+				get: { self.isLastPage },
+				set: { self.isLastPage = $0 }
 			)
-		}
+		)
+	}
+	
+	/// 장소를 검색합니다.
+	/// 기존 검색 결과를 초기화하고 새로운 검색 결과를 받아와 저장합니다.
+	func search() {
+		if query.isEmpty { return }
 		
-		func loadMore() {
-			if query.isEmpty { return }
-			if isLastPage { return }
-			
-			currentPage += 1
-			
-			kakaoAPIService.loadPlaces(
-				query: query,
-				page: currentPage,
-				pageSize: pageSize,
-				places: Binding(
-					get: { self.searchedItems },
-					set: { self.searchedItems = $0 }
-				),
-				isLastPage: Binding(
-					get: { self.isLastPage },
-					set: { self.isLastPage = $0 }
-				)
-			)
-		}
+		// 초기화
+		currentPage = 1
+		searchedItems.removeAll()
+		isLastPage = false
 		
-		func isSelected(_ item: Place) -> Bool {
-			return self.selectedItems.contains(item)
-		}
+		// 검색
+		fetchSearchedItems()
+	}
+	
+	/// 장소를 검색합니다.
+	/// 다음 페이지의 검색 결과를 받아와 기존 검색 결과의 끝에 추가합니다.
+	func searchNextPage() {
+		if query.isEmpty { return }
+		if isLastPage { return }
 		
-		func addSelectedItem(_ item: Place) {
-			if !isSelected(item) {
-				self.selectedItems.append(item)
-			}
-		}
+		currentPage += 1
 		
-		func removeSelectedItem(_ item: Place) {
-			if let index = self.selectedItems.firstIndex(of: item) {
-				self.selectedItems.remove(at: index)
-			}
+		fetchSearchedItems()
+	}
+}
+
+
+// MARK: - 장소 선택 기능
+
+extension PlaceSearchScreen.ViewModel {
+	/// 해당 장소가 선택된 상태인지의 여부를 반환합니다.
+	func isSelected(_ item: Place) -> Bool {
+		return self.selectedItems.contains(item)
+	}
+	
+	/// 해당 장소가 선택되어 있지 않다면, 선택합니다.
+	func addSelectedItem(_ item: Place) {
+		if !isSelected(item) {
+			self.selectedItems.append(item)
+		}
+	}
+	
+	/// 해당 장소에 대한 선택을 취소합니다.
+	func removeSelectedItem(_ item: Place) {
+		if let index = self.selectedItems.firstIndex(of: item) {
+			self.selectedItems.remove(at: index)
 		}
 	}
 }

--- a/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchViewModel.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/PlaceSearchScreen/PlaceSearchViewModel.swift
@@ -30,5 +30,21 @@ extension PlaceSearchScreen {
 				)
 			)
 		}
+		
+		func isSelected(_ item: Place) -> Bool {
+			return self.selectedItems.contains(item)
+		}
+		
+		func addSelectedItem(_ item: Place) {
+			if !isSelected(item) {
+				self.selectedItems.append(item)
+			}
+		}
+		
+		func removeSelectedItem(_ item: Place) {
+			if let index = self.selectedItems.firstIndex(of: item) {
+				self.selectedItems.remove(at: index)
+			}
+		}
 	}
 }

--- a/HeyLocal/HeyLocal/Utils/Config.swift
+++ b/HeyLocal/HeyLocal/Utils/Config.swift
@@ -12,4 +12,6 @@ struct Config {
 	static let apiURL = Bundle.main.object(forInfoDictionaryKey: "API_URL")!
 	static let accessToken = Bundle.main.object(forInfoDictionaryKey: "ACCESS_TOKEN")!
 	static let refreshToken = Bundle.main.object(forInfoDictionaryKey: "REFRESH_TOKEN")!
+	static let kakaoRestURL = Bundle.main.object(forInfoDictionaryKey: "KAKAO_REST_URL")!
+	static let kakaoRestKey = Bundle.main.object(forInfoDictionaryKey: "KAKAO_REST_KEY")!
 }

--- a/HeyLocal/HeyLocal/Utils/NetworkAgent.swift
+++ b/HeyLocal/HeyLocal/Utils/NetworkAgent.swift
@@ -14,7 +14,9 @@ struct NetworkAgent {
 	func run<T: Decodable>(_ request: URLRequest) -> AnyPublisher<T, Error> {
 		return session
 			.dataTaskPublisher(for: request)
-			.tryMap(handleAPIError)
+//			.tryMap(handleAPIError)
+			.map(\.data)
+			.handleEvents(receiveOutput: { print(NSString(data: $0, encoding: String.Encoding.utf8.rawValue)!) }) // LOG
 			.decode(type: T.self, decoder: JSONDecoder())
 			.receive(on: DispatchQueue.main)
 			.eraseToAnyPublisher()


### PR DESCRIPTION
## Changes

- [x] 카카오 API 연동
- [x] 장소 검색 화면 구현
- [x] 플랜 상세 화면에서 장소 추가 기능 구현

## Note

- `Authorization.xcconfig` 파일이 업데이트 되었습니다. Confluence '개발 참고 자료'에서 확인 바람! (변경 사항 : 카카오 REST API Key 추가)

## Screenshot

|장소 검색 화면|
|:---:|
|![](https://user-images.githubusercontent.com/76616101/192342828-e4be4d45-842e-4a79-83a1-47733d911661.png)|
