### PR TITLE
[S3T-523] 마이플랜 화면과 플랜 상세 화면에서 플랜 제목 출력

### DIFF
--- a/HeyLocal/HeyLocal/Models/Plan.swift
+++ b/HeyLocal/HeyLocal/Models/Plan.swift
@@ -17,6 +17,7 @@ struct MyPlans: Decodable {
 /// 플랜
 struct Plan: Decodable {
 	var id: Int
+	var title: String
 	var regionId: Int
 	var regionState: String
 	var regionCity: String?

--- a/HeyLocal/HeyLocal/UI/Components/MyPlanList/MyPlanList.swift
+++ b/HeyLocal/HeyLocal/UI/Components/MyPlanList/MyPlanList.swift
@@ -67,7 +67,7 @@ extension MyPlanList {
 				
 				VStack(alignment: .leading, spacing: 0) {
 					// 제목
-					Text(plan.regionName)
+					Text(plan.title)
 						.font(.system(size: 16))
 						.fontWeight(.bold)
 					

--- a/HeyLocal/HeyLocal/UI/Screens/MyPlanScreen/PlanDetailScreen.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/MyPlanScreen/PlanDetailScreen.swift
@@ -45,7 +45,7 @@ struct PlanDetailScreen: View {
 	var header: some View {
 		HStack {
 			VStack(alignment: .leading) {
-				Text("\(plan.regionState) \(plan.regionCity ?? "") 여행")
+				Text(plan.title)
 					.font(.title2)
 					.fontWeight(.bold)
 				Text(DateFormat.format(plan.startDate, from: "yyyy-MM-dd", to: "M월 d일") + " ~ " + DateFormat.format(plan.endDate, from: "yyyy-MM-dd", to: "M월 d일"))
@@ -128,6 +128,6 @@ struct PlanDetailScreen: View {
 
 struct PlanDetailScreen_Previews: PreviewProvider {
     static var previews: some View {
-		PlanDetailScreen(plan: Plan(id: 1, regionId: 1, regionState: "서울특별시", regionCity: "강남구", startDate: "2022-09-01", endDate: "2022-09-03"))
+		PlanDetailScreen(plan: Plan(id: 1, title: "서울, 서울, 서울!", regionId: 1, regionState: "서울특별시", regionCity: "강남구", startDate: "2022-09-01", endDate: "2022-09-03"))
     }
 }


### PR DESCRIPTION
## Changes

- 기존에는 여행 지역으로 출력했는데, 플랜 제목으로 변경
- `Plan` 모델에 `title` 추가
- 각 뷰 수정