### PR TITLE
[S3T-539] 다크 모드 비활성화

### DIFF
--- a/HeyLocal/HeyLocal/Info.plist
+++ b/HeyLocal/HeyLocal/Info.plist
@@ -19,6 +19,8 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>REFRESH_TOKEN</key>
 	<string>${REFRESH_TOKEN}</string>
 </dict>


### PR DESCRIPTION
## Changes

- iOS 설정이 다크 모드인 상태에서도 라이트 모드로 실행되도록 설정 변경