### PR TITLE
[S3T-552] 카카오 로컬 API에서 카테고리 값을 주지 않는 경우에 대한 처리

### DIFF
--- a/HeyLocal/HeyLocal/Services/KakaoAPIService.swift
+++ b/HeyLocal/HeyLocal/Services/KakaoAPIService.swift
@@ -91,7 +91,7 @@ struct KakaoPlacesResponse: Decodable {
 			Place(
 				id: Int(id) ?? 0,
 				name: name,
-				category: category,
+				category: "\(PlaceCategory.withLabel(category))",
 				address: address,
 				roadAddress: roadAddress,
 				lat: Double(lat) ?? 0.0,


### PR DESCRIPTION
## Changes

- 카카오 로컬 API에서 카테고리 값을 빈 문자열로 주는 경우, 엔티티에서 `Place` 모델로 변환되는 시점에 "ETC" 문자열로 카테고리 값이 들어가도록 수정
- 카테고리가 '기타'인 장소를 스케줄에 추가할 수 없었던 문제 수정