### PR TITLE
[S3T-666] 여행On에서 마이플랜으로 바로 이동하는 기능 구현

### DIFF
--- a/HeyLocal/HeyLocal.xcodeproj/project.pbxproj
+++ b/HeyLocal/HeyLocal.xcodeproj/project.pbxproj
@@ -1090,7 +1090,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 20221111;
 				DEVELOPMENT_ASSET_PATHS = "\"HeyLocal/Preview Content\"";
-				DEVELOPMENT_TEAM = 3X3P9744G9;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				EXCLUDED_ARCHS = "";
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
@@ -1138,7 +1138,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 20221111;
 				DEVELOPMENT_ASSET_PATHS = "\"HeyLocal/Preview Content\"";
-				DEVELOPMENT_TEAM = 3X3P9744G9;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/HeyLocal/HeyLocal/Repositories/OpinionRepository.swift
+++ b/HeyLocal/HeyLocal/Repositories/OpinionRepository.swift
@@ -238,13 +238,13 @@ struct OpinionRepository {
                             let generalPUTs = responseURLs[i].putUrls
                             let generalDELETEs = responseURLs[i].deleteUrls
                             
-                            var running = false
+//                            var running = false
                             
                             
                             print("DELETE URLs", generalDELETEs)
                             // 삭제 진행 후
                             if !deleteImages.isEmpty {
-                                running = true
+//                                running = true
                                 
                                 for i in 0..<deleteImages.count {
                                     let deleteURL = URL(string: generalDELETEs[deleteImages[i]])!
@@ -263,14 +263,14 @@ struct OpinionRepository {
                                     
                                     sleep(UInt32(0.5))
                                 }
-                                running = false
+//                                running = false
                             }
                             
 //                            // Delay
 //                            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.5) {
 //                                print("wait")
 //                            }
-                            while running {}
+//                            while running {}
                             
                             
                             // reUpload

--- a/HeyLocal/HeyLocal/Repositories/TravelOnRepository.swift
+++ b/HeyLocal/HeyLocal/Repositories/TravelOnRepository.swift
@@ -90,6 +90,35 @@ struct TravelOnRepository {
         return agent.run(request)
     }
     
+    // 여행On에 등록된 플랜 조회
+    func getPlan(travelOnId: Int, plan: Binding<Plan>) {
+        let urlString = "\(travelonUrl)/\(travelOnId)/plan"
+        let url = URL(string: urlString)!
+        var request = URLRequest(url: url)
+        
+        // HTTP 헤더 구성
+        request.httpMethod = "GET"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+        request.addValue("Bearer \(AuthManager.shared.accessToken)", forHTTPHeaderField: "Authorization")
+        
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            guard let data = data, let httpResponse = response as? HTTPURLResponse, error == nil else {
+                print(error?.localizedDescription ?? "No DATA")
+                return
+            }
+            
+            if httpResponse.statusCode == 200 {
+                do {
+                    let result = try JSONDecoder().decode(Plan.self, from: data)
+                    plan.wrappedValue = result
+                    print("\(result.regionId)")
+                } catch {
+                    print("ERROR")
+                }
+            }
+        }.resume()
+    }
     
     // 여행On 등록 API
     func postTravelOn(travelOnData: TravelOnPost) -> Int {

--- a/HeyLocal/HeyLocal/Services/KakaoAPIService.swift
+++ b/HeyLocal/HeyLocal/Services/KakaoAPIService.swift
@@ -122,8 +122,9 @@ class KakaoAPIService {
                 do {
                     let result = try JSONDecoder().decode(KakaoImageResponse.self, from: data)
 					DispatchQueue.main.async {
-						place.wrappedValue.thumbnailUrl = result.documents.map(\.image_url)[0]
-						print("Thumbnail Image URL : \(place.wrappedValue.thumbnailUrl!)")
+                        if !result.documents.map(\.image_url).isEmpty {
+                            place.wrappedValue.thumbnailUrl = result.documents.map(\.image_url)[0]
+                        }
 					}
                 } catch {
                     print("error")

--- a/HeyLocal/HeyLocal/UI/Components/OpinionComponent/OpinionComponent.swift
+++ b/HeyLocal/HeyLocal/UI/Components/OpinionComponent/OpinionComponent.swift
@@ -13,7 +13,6 @@ struct OpinionComponent: View {
     
     var body: some View {
         HStack(alignment: .top) {
-            // TODO: 답변 사진으로 대체
             if opinion.generalImgDownloadImgUrl.isEmpty {
                 if opinion.place.thumbnailUrl != nil {
                     AsyncImage(url: URL(string: opinion.place.thumbnailUrl!)) { phash in
@@ -22,7 +21,8 @@ struct OpinionComponent: View {
                                 .resizable()
                                 .aspectRatio(contentMode: .fill)
                                 .frame(width: 100, height: 100)
-                                .cornerRadius(10.0)   
+                                .clipped()
+                                .cornerRadius(10.0)
                         }
                         else {
                             Rectangle()
@@ -44,8 +44,9 @@ struct OpinionComponent: View {
                         image
                             .resizable()
                             .aspectRatio(contentMode: .fill)
-                            .cornerRadius(10.0)
                             .frame(width: 100, height: 100)
+                            .clipped()
+                            .cornerRadius(10.0)
                     }
                     else {
                         Rectangle()

--- a/HeyLocal/HeyLocal/UI/Screens/HomeScreen/HomeScreen.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/HomeScreen/HomeScreen.swift
@@ -87,7 +87,11 @@ struct HomeScreen: View {
             .background(Color("lightGray"))
             .navigationBarTitle("", displayMode: .automatic)
             .navigationBarItems(
-				leading: Image("logo").resizable().frame(width: 93, height: 36)
+				leading: Image("login-symbol")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 36)
+                    .padding(EdgeInsets(top: 0, leading: 5, bottom: 5, trailing: 0))
 //				,trailing: alarmButton // TODO: 알림 기능
 			)
             .navigationViewStyle(StackNavigationViewStyle())

--- a/HeyLocal/HeyLocal/UI/Screens/HomeScreen/HomeScreen.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/HomeScreen/HomeScreen.swift
@@ -126,6 +126,7 @@ extension HomeScreen {
             VStack(alignment: .leading) {
                 Text("요즘 HOT한 장소🔥")
                     .font(.system(size: 16))
+                    .fontWeight(.semibold)
                     .padding(EdgeInsets(top: 20, leading: 20, bottom: 0, trailing: 0))
                 
                 ScrollView(.horizontal, showsIndicators: false) {
@@ -155,6 +156,7 @@ extension HomeScreen {
             VStack(alignment: .leading) {
                 Text("현지인의 추천이 궁금해요😮")
                     .font(.system(size: 16))
+                    .fontWeight(.semibold)
                     .padding(EdgeInsets(top: 20, leading: 20, bottom: 0, trailing: 20))
                 
                 ForEach(viewModel.travelOns) { travelOn in
@@ -181,6 +183,7 @@ extension HomeScreen {
                 HStack {
                     Text("노하우 랭킹👑")
                         .font(.system(size: 16))
+                        .fontWeight(.semibold)
                     
                     Spacer()
                     

--- a/HeyLocal/HeyLocal/UI/Screens/OpinionScreen/OpinionViewModel.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/OpinionScreen/OpinionViewModel.swift
@@ -69,7 +69,7 @@ extension OpinionComponent {
         
         var cancellable: AnyCancellable?
         init() {
-            self.opinions = [Opinion()]
+            self.opinions = [Opinion]()
             self.opinion = Opinion()
         }
         

--- a/HeyLocal/HeyLocal/UI/Screens/TravelOnScreen/TravelOnDetailScreen.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/TravelOnScreen/TravelOnDetailScreen.swift
@@ -7,12 +7,13 @@
 //
 
 import SwiftUI
+import AVFAudio
 
 //TravelOnDetailScreen
 struct TravelOnDetailScreen: View {
     @State var travelOnId: Int
     @StateObject var viewModel = TravelOnListScreen.ViewModel()
-	@Environment(\.dismiss) var dismiss
+    @Environment(\.dismiss) var dismiss
     @Environment(\.displayTabBar) var displayTabBar
     
     @State var showingSheet = false
@@ -27,7 +28,7 @@ struct TravelOnDetailScreen: View {
 //            if navigationLinkActive {
 //                NavigationLink("", destination: TravelOnWriteScreen(isRevise: true, travelOnID: viewModel.travelOn.id), isActive: $navigationLinkActive)
 //            }
-//            
+//
             NavigationLink(destination: TravelOnWriteScreen(isRevise: true, travelOnID: viewModel.travelOn.id), isActive: $navigationLinkActive) {
                 Text("")
             }
@@ -45,7 +46,7 @@ struct TravelOnDetailScreen: View {
                 Spacer()
                     .frame(height: 8)
                 
-                TravelOnOpinion(travelOnId: travelOnId, showingModal: $showingModal, regionId: viewModel.travelOn.region.id)
+                TravelOnOpinion(travelon: viewModel.travelOn, travelOnId: travelOnId, showingModal: $showingModal, regionId: viewModel.travelOn.region.id)
                     .alert(isPresented: $showingReportAlert) {
                         Alert(title: Text("여행On 신고"),
                               message: Text("해당 여행On을 신고할까요?"),
@@ -63,9 +64,9 @@ struct TravelOnDetailScreen: View {
                             cancelWidth: 134,
                             confirmWidth: 109,
                             rightButtonAction: {
-                    			viewModel.deleteTravelOn(travelOnId: viewModel.travelOn.id)
-								dismiss()
-							},
+                                viewModel.deleteTravelOn(travelOnId: viewModel.travelOn.id)
+                                dismiss()
+                            },
                             destinationView: AnyView(TravelOnListScreen()))
             }
             
@@ -530,7 +531,9 @@ struct TravelOnDetailScreen: View {
 extension TravelOnDetailScreen {
     struct TravelOnOpinion: View {
         @StateObject var viewModel = TravelOnListScreen.ViewModel()
+        @StateObject var planViewModel = PlanCreateScreen.ViewModel()
         
+        var travelon: TravelOn
         var travelOnId: Int
         @Binding var showingModal: Bool
         var regionId: Int
@@ -587,32 +590,58 @@ extension TravelOnDetailScreen {
                         }
                         
                         Spacer()
-                            .frame(width: 12)
+                            .frame(width: 20)
                         
-                        // 답변쓰기 버튼
-                        Button(action: {
-                            if let region = viewModel.profile.activityRegion {
-                                if region.id == regionId {
-                                    opinionWriteActive.toggle()
+                        if viewModel.profile.id == travelon.author.id {
+                            // 마이플랜 생성 
+                            Button(action: {
+                                planViewModel.selected = travelon
+                                planViewModel.submit{
+                                    
+                                    // 페이지 이동 ?
+                                } onError : { error in
+                                    let apiError: APIError = error as! APIError
+                                    planViewModel.displayAlert(apiError.description)
                                 }
-                                else {
-                                    // 지역이 같은 유저만 가능한 ~
+                            }) {
+                                // Label
+                                ZStack {
+                                    RoundedRectangle(cornerRadius: 100)
+                                        .fill(Color("orange"))
+                                        .frame(width: 294, height: 44)
+                                    
+                                    Text("해당 마이플랜 보러가기")
+                                        .font(.system(size: 16))
+                                        .foregroundColor(.white)
+                                }
+                            }
+                        }
+                        else {
+                            // 답변쓰기 버튼
+                            Button(action: {
+                                if let region = viewModel.profile.activityRegion {
+                                    if region.id == regionId {
+                                        opinionWriteActive.toggle()
+                                    }
+                                    else {
+                                        // 지역이 같은 유저만 가능한 ~
+                                        showingModal.toggle()
+                                    }
+                                } else {
+                                    // 지역 설정이 필요 , 또한 지역이 같은 유저만 가능한 ~
                                     showingModal.toggle()
                                 }
-                            } else {
-                                // 지역 설정이 필요 , 또한 지역이 같은 유저만 가능한 ~
-                                showingModal.toggle()
-                            }
-                        }) {
-                            // Label
-                            ZStack {
-                                RoundedRectangle(cornerRadius: 100)
-                                    .fill(Color("orange"))
-                                    .frame(width: 294, height: 44)
-                                
-                                Text("나도 추천하기")
-                                    .font(.system(size: 16))
-                                    .foregroundColor(.white)
+                            }) {
+                                // Label
+                                ZStack {
+                                    RoundedRectangle(cornerRadius: 100)
+                                        .fill(Color("orange"))
+                                        .frame(width: 294, height: 44)
+                                    
+                                    Text("나도 추천하기")
+                                        .font(.system(size: 16))
+                                        .foregroundColor(.white)
+                                }
                             }
                         }
                         

--- a/HeyLocal/HeyLocal/UI/Screens/TravelOnScreen/TravelOnDetailScreen.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/TravelOnScreen/TravelOnDetailScreen.swift
@@ -528,16 +528,28 @@ struct TravelOnDetailScreen: View {
     }
 }
 
+
+
 extension TravelOnDetailScreen {
     struct TravelOnOpinion: View {
         @StateObject var viewModel = TravelOnListScreen.ViewModel()
         @StateObject var planViewModel = PlanCreateScreen.ViewModel()
+        var travelOnRepository = TravelOnRepository()
+        
         
         var travelon: TravelOn
         var travelOnId: Int
         @Binding var showingModal: Bool
         var regionId: Int
         @State var opinionWriteActive: Bool = false
+        @State var planNavigationActive: Bool = false
+        @State var plan: Plan = Plan(id: 0,
+                                     title: "마이플랜",
+                                     regionId: 0,
+                                     regionState: "",
+                                     startDate: "2022-11-13",
+                                     endDate: "2022-11-13",
+                                     transportationType: "OWN_CAR")
         
         var body: some View {
             VStack(alignment: .leading) {
@@ -597,11 +609,20 @@ extension TravelOnDetailScreen {
                             Button(action: {
                                 planViewModel.selected = travelon
                                 planViewModel.submit{
+                                    travelOnRepository.getPlan(travelOnId: travelOnId, plan: Binding(get: { plan },
+                                                                                                     set: { plan = $0 }))
                                     
-                                    // 페이지 이동 ?
+                                    planNavigationActive.toggle()
+                                    print("\(planNavigationActive.description)")
                                 } onError : { error in
                                     let apiError: APIError = error as! APIError
                                     planViewModel.displayAlert(apiError.description)
+                                    
+                                    travelOnRepository.getPlan(travelOnId: travelOnId, plan: Binding(get: { plan },
+                                                                                                     set: { plan = $0 }))
+                                    
+                                    planNavigationActive.toggle()
+                                    print("\(planNavigationActive.description)")
                                 }
                             }) {
                                 // Label
@@ -610,7 +631,7 @@ extension TravelOnDetailScreen {
                                         .fill(Color("orange"))
                                         .frame(width: 294, height: 44)
                                     
-                                    Text("해당 마이플랜 보러가기")
+                                    Text("해당 마이플랜으로 이동하기")
                                         .font(.system(size: 16))
                                         .foregroundColor(.white)
                                 }
@@ -642,6 +663,12 @@ extension TravelOnDetailScreen {
                                         .font(.system(size: 16))
                                         .foregroundColor(.white)
                                 }
+                            }
+                        }
+                        
+                        if planNavigationActive {
+                            NavigationLink(destination: PlanDetailScreen(plan: plan), isActive: $planNavigationActive){
+                                Text("")
                             }
                         }
                         

--- a/HeyLocal/HeyLocal/UI/Screens/TravelOnScreen/TravelOnViewModel.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/TravelOnScreen/TravelOnViewModel.swift
@@ -311,7 +311,6 @@ func getRegion(regionId: Int) -> String {
 
     task.resume()
     
-    task.resume()
     result = regionNameFormatter(region: resultRegion)
     print("===========\(resultRegion.state)======")
     return result


### PR DESCRIPTION
## Changes

- 여행On 상세조회 시, 내가 작성한 여행On에서는 `답변 쓰기` 버튼 대신 `마이플랜 조회` 버튼으로 수정
- `마이플랜 조회` 버튼 클릭 시, 해당 마이플랜 상세조회 화면으로 이동
- 만일 이때 마이플랜이 없다면 생성 후 화면 이동

## Screenshot
![image](https://user-images.githubusercontent.com/37467592/201513922-5594e6ef-e985-4436-a341-8ec5411b2faa.png)
