### PR TITLE
[S3T-689] 답변 작성 시, 추천 메뉴 섹션의 텍스트 필드가 잘 선택이 안되는 문제 수정

### DIFF
--- a/HeyLocal/HeyLocal/UI/Screens/OpinionScreen/OpinionWriteScreen.swift
+++ b/HeyLocal/HeyLocal/UI/Screens/OpinionScreen/OpinionWriteScreen.swift
@@ -1048,25 +1048,15 @@ struct OpinionWriteScreen: View {
                 Spacer()
                     .frame(height: 5)
                 
-                ZStack(alignment: .leading) {
-                    TextField("", text: $viewModel.opinion.recommendFoodDescription)
-                        .multilineTextAlignment(TextAlignment.leading)
-                        .font(.system(size: 12))
-                        .foregroundColor(Color("gray"))
-                        .frame(width: 360, height: 40)
-                        .overlay(RoundedRectangle(cornerRadius: 10.0).strokeBorder(Color("mediumGray"), style: StrokeStyle(lineWidth: 1.0)))
-                        .background(Color(red: 248 / 255, green: 248 / 255, blue: 248 / 255))
-                        .cornerRadius(10)
-                    
-                    if viewModel.opinion.recommendFoodDescription == "" {
-                        VStack(alignment: .leading) {
-                            Text("25자 이내로 작성해주세요")
-                        }
-                        .padding()
-                        .font(.system(size: 12))
-                        .foregroundColor(Color("gray"))
-                    }
-                }
+				TextField("25자 이내로 작성해주세요", text: $viewModel.opinion.recommendFoodDescription)
+					.multilineTextAlignment(TextAlignment.leading)
+					.font(.system(size: 12))
+					.foregroundColor(Color("gray"))
+					.frame(width: 360, height: 40)
+					.padding(.leading, 8)
+					.overlay(RoundedRectangle(cornerRadius: 10.0).strokeBorder(Color("mediumGray"), style: StrokeStyle(lineWidth: 1.0)))
+					.background(Color(red: 248 / 255, green: 248 / 255, blue: 248 / 255))
+					.cornerRadius(10)
             }
         }
         .padding()
@@ -1264,26 +1254,16 @@ struct OpinionWriteScreen: View {
                 
                 Spacer()
                     .frame(height: 5)
-                
-                ZStack(alignment: .leading) {
-                    TextField("", text: $viewModel.opinion.recommendDrinkAndDessertDescription)
-                        .multilineTextAlignment(TextAlignment.leading)
-                        .font(.system(size: 12))
-                        .foregroundColor(Color("gray"))
-                        .frame(width: 360, height: 40)
-                        .overlay(RoundedRectangle(cornerRadius: 10.0).strokeBorder(Color("mediumGray"), style: StrokeStyle(lineWidth: 1.0)))
-                        .background(Color(red: 248 / 255, green: 248 / 255, blue: 248 / 255))
-                        .cornerRadius(10)
-                    
-                    if viewModel.opinion.recommendDrinkAndDessertDescription == "" {
-                        VStack(alignment: .leading) {
-                            Text("25자 이내로 작성해주세요")
-                        }
-                        .padding()
-                        .font(.system(size: 12))
-                        .foregroundColor(Color("gray"))
-                    }
-                }
+				
+				TextField("25자 이내로 작성해주세요", text: $viewModel.opinion.recommendDrinkAndDessertDescription)
+					.multilineTextAlignment(TextAlignment.leading)
+					.font(.system(size: 12))
+					.foregroundColor(Color("gray"))
+					.frame(width: 360, height: 40)
+					.padding(.leading, 8)
+					.overlay(RoundedRectangle(cornerRadius: 10.0).strokeBorder(Color("mediumGray"), style: StrokeStyle(lineWidth: 1.0)))
+					.background(Color(red: 248 / 255, green: 248 / 255, blue: 248 / 255))
+					.cornerRadius(10)
             }
             
             Spacer()


### PR DESCRIPTION
## Problem

- 답변 작성 화면에서 추천 메뉴 섹션의 텍스트 필드를 입력하려고 터치했을 때, 잘 선택이 되지 않음
- ‘25자 이내로 작성해주세요’ 텍스트가 위에 쌓여 있는 것 같은데, 해당 텍스트 영역에 텍스트 필드가 가려져서 생기는 문제로 보임

## Changes

- 기존에 `ZStack`을 이용하여 텍스트 필드 위에 placeholder 텍스트가 쌓여 있는 구조에서, `TextField`의 `placeholder` 파라미터를 통해 placeholder를 표시하도록 수정