### PR TITLE
[S3T-733] 장소 이미지가 없는 경우의 앱 충돌 문제 해결

### DIFF
--- a/HeyLocal/HeyLocal/Models/Place.swift
+++ b/HeyLocal/HeyLocal/Models/Place.swift
@@ -22,7 +22,7 @@ struct Place: Codable, Identifiable, Hashable {
 	var itemIndex: Int?
 	var arrivalTime: String?
     var region: Region?
-    var thumbnailUrl: String? = ""
+    var thumbnailUrl: String?
     
 	/// 카테고리의 이름 (ex. 음식점)
 	var categoryName: String {

--- a/HeyLocal/HeyLocal/Services/KakaoAPIService.swift
+++ b/HeyLocal/HeyLocal/Services/KakaoAPIService.swift
@@ -74,15 +74,12 @@ class KakaoAPIService {
                 print(error?.localizedDescription ?? "NO Data")
                 return
             }
+			
             if httpResponse.statusCode == 200 {
                 do {
                     let result = try JSONDecoder().decode(KakaoImageResponse.self, from: data)
 					DispatchQueue.main.async {
-                        if place.wrappedValue.thumbnailUrl == nil { // ?? out of range
-                            place.wrappedValue.thumbnailUrl = ""
-                            place.wrappedValue.thumbnailUrl = result.documents[0].image_url
-                        }
-                        place.wrappedValue.thumbnailUrl = result.documents[0].image_url
+						place.wrappedValue.thumbnailUrl = result.documents.first?.image_url
 					}
                 } catch {
                     print("error")


### PR DESCRIPTION
## Changes

- 장소 검색(ex. 답변 등록할 때) 시, 장소의 이미지를 불러올 때 만약 이미지 검색 결과가 없다면 Index out of range 에러 발생하는 문제 해결
- `Place` 모델 구조체에서 옵셔널 타입인 `thumbnailUrl` 프로퍼티에 대한 기본값(빈 문자열) 제거