### PR TITLE
[S3T-732] 여행On 제목 정렬 버그 수정

### DIFF
--- a/HeyLocal/HeyLocal/UI/Components/TravelOnComponent/TravelOnComponent.swift
+++ b/HeyLocal/HeyLocal/UI/Components/TravelOnComponent/TravelOnComponent.swift
@@ -58,6 +58,7 @@ struct TravelOnComponent: View {
                 Text("\(travelOn.title)")
                     .font(.system(size: 14))
                     .fontWeight(.medium)
+                    .multilineTextAlignment(.leading)
                 
                 Spacer()
                     .frame(height: 10)


### PR DESCRIPTION
## Changes

- 여행On 리스트에서 제목이 길 때, 정렬이 깨지는 문제 해결

## Screenshot 
| <img width="228" alt="image" src="https://user-images.githubusercontent.com/37467592/202953007-9e1e8177-f1ae-48d4-8561-0d6ead3cd2a4.png"> | <img width="228" alt="image" src="https://user-images.githubusercontent.com/37467592/202952901-9ef1a00b-6239-4e05-905c-cc575f04a243.png"> |
| ------------------------------------------------------------------- | ------------------------------------------------------------------- |



